### PR TITLE
self.new -> new

### DIFF
--- a/lib/overloader/core.rb
+++ b/lib/overloader/core.rb
@@ -3,7 +3,7 @@ module Overloader
     using AstExt
 
     def self.define_overload(klass, proc)
-      self.new(klass, proc).define_overload
+      new(klass, proc).define_overload
     end
 
     def initialize(klass, proc)


### PR DESCRIPTION
Great project! Reading the code I notice `self.new` where `self` is implicit, so it can be just `new`. You might prefer `self.new`, if so ignore/close this PR.